### PR TITLE
Allow to use different command other than 'ffmpeg'

### DIFF
--- a/ffmpeg/__init__.py
+++ b/ffmpeg/__init__.py
@@ -220,9 +220,11 @@ class _OutputNode(_Node):
         args += reduce(operator.add, [self._get_output_args(node, stream_name_map) for node in output_nodes])
         args += reduce(operator.add, [self._get_global_args(node) for node in global_nodes], [])
         return args
-
-    def run(self):
-        args = ['ffmpeg'] + self.get_args()
+    
+    def run(self, cmd='ffmpeg'):
+        if type(cmd) == str:
+            cmd = [cmd]
+        args = cmd + self.get_args()
         subprocess.check_call(args)
 
 


### PR DESCRIPTION
Add "cmd" argument to run that allows to provide different command for ffmpeg (e.g. you may want to use `avconv` or a wrapper).