### PR TITLE
Convert assertions to if+raise

### DIFF
--- a/ffmpeg/_ffmpeg.py
+++ b/ffmpeg/_ffmpeg.py
@@ -16,7 +16,8 @@ def input(filename, **kwargs):
     kwargs['filename'] = filename
     fmt = kwargs.pop('f', None)
     if fmt:
-        assert 'format' not in kwargs, "Can't specify both `format` and `f` kwargs"
+        if 'format' in kwargs:
+            raise ValueError("Can't specify both `format` and `f` kwargs")
         kwargs['format'] = fmt
     return InputNode(input.__name__, **kwargs)
 
@@ -46,7 +47,8 @@ def output(parent_node, filename, **kwargs):
     kwargs['filename'] = filename
     fmt = kwargs.pop('f', None)
     if fmt:
-        assert 'format' not in kwargs, "Can't specify both `format` and `f` kwargs"
+        if 'format' in kwargs:
+            raise ValueError("Can't specify both `format` and `f` kwargs")
         kwargs['format'] = fmt
     return OutputNode([parent_node], output.__name__, **kwargs)
 

--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -47,7 +47,7 @@ def _get_input_args(input_node):
         args += _convert_kwargs_to_cmd_line_args(kwargs)
         args += ['-i', filename]
     else:
-        assert False, 'Unsupported input node: {}'.format(input_node)
+        raise ValueError('Unsupported input node: {}'.format(input_node))
     return args
 
 
@@ -56,7 +56,8 @@ def _topo_sort(start_node):
     sorted_nodes = []
     child_map = {}
     def visit(node, child):
-        assert node not in marked_nodes, 'Graph is not a DAG'
+        if node in marked_nodes:
+            raise RuntimeError('Graph is not a DAG')
         if child is not None:
             if node not in child_map:
                 child_map[node] = []
@@ -89,7 +90,7 @@ def _get_global_args(node):
     if node._name == overwrite_output.__name__:
         return ['-y']
     else:
-        assert False, 'Unsupported global node: {}'.format(node)
+        raise ValueError('Unsupported global node: {}'.format(node))
 
 
 def _get_output_args(node, stream_name_map):
@@ -107,7 +108,7 @@ def _get_output_args(node, stream_name_map):
             args += _convert_kwargs_to_cmd_line_args(kwargs)
             args += [filename]
         else:
-            assert False, 'Unsupported output node: {}'.format(node)
+            raise ValueError('Unsupported output node: {}'.format(node))
     return args
 
 

--- a/ffmpeg/nodes.py
+++ b/ffmpeg/nodes.py
@@ -9,7 +9,8 @@ class Node(object):
     """Node base"""
     def __init__(self, parents, name, *args, **kwargs):
         parent_hashes = [hash(parent) for parent in parents]
-        assert len(parent_hashes) == len(set(parent_hashes)), 'Same node cannot be included as parent multiple times'
+        if len(parent_hashes) != len(set(parent_hashes)):
+            raise ValueError('Same node cannot be included as parent multiple times')
         self._parents = parents
         self._hash = None
         self._name = name
@@ -65,7 +66,8 @@ class OutputNode(Node):
 
 class GlobalNode(Node):
     def __init__(self, parent, name, *args, **kwargs):
-        assert isinstance(parent, OutputNode), 'Global nodes can only be attached after output nodes'
+        if not isinstance(parent, OutputNode):
+            raise RuntimeError('Global nodes can only be attached after output nodes')
         super(GlobalNode, self).__init__([parent], name, *args, **kwargs)
 
 


### PR DESCRIPTION
Assertions are ignored if the interpreter is run with the `-O` (optimize).

I converted all assertions outside of tests to normal exceptions.

Please review the type of the exceptions (maybe we could define some new, module-specific ones), I tried to use the most meaningful ones (basically all `ValueError` and one `RuntimeError`).