### PR TITLE
Add splits positional argument to specify the number of split nodes

### DIFF
--- a/ffmpeg/_filters.py
+++ b/ffmpeg/_filters.py
@@ -50,8 +50,8 @@ def filter_(stream_spec, filter_name, *args, **kwargs):
 
 
 @filter_operator()
-def split(stream):
-    return FilterNode(stream, split.__name__)
+def split(stream, splits=None):
+    return FilterNode(stream, split.__name__, args=[splits] if splits else [],)
 
 
 @filter_operator()

--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import warnings
+
 from .dag import get_outgoing_edges, topo_sort
 from functools import reduce
 from past.builtins import basestring
@@ -70,8 +72,8 @@ def _allocate_filter_stream_names(filter_nodes, outgoing_edge_maps, stream_name_
         for upstream_label, downstreams in outgoing_edge_map.items():
             if len(downstreams) > 1:
                 # TODO: automatically insert `splits` ahead of time via graph transformation.
-                raise ValueError('Encountered {} with multiple outgoing edges with same upstream label {!r}; a '
-                    '`split` filter is probably required'.format(upstream_node, upstream_label))
+                warnings.warn('Encountered {} with multiple outgoing edges with same upstream label {!r}; a '
+                    '`split` filter is probably required'.format(upstream_node, upstream_label), RuntimeWarning)
             stream_name_map[upstream_node, upstream_label] = _get_stream_name('s{}'.format(stream_count))
             stream_count += 1
 


### PR DESCRIPTION
```python
import ffmpeg

i = ffmpeg.input("test.ogg")
s = i.split(5)
l = [s[i].output("out"+str(i)) for i in range(5)]

o = ffmpeg.merge_outputs(*l)
print(o.get_args())
```
```python
['-i', 'test.ogg', '-filter_complex', '[0]split=5[s0][s1][s2][s3][s4]', '-map', '[s0]', 'out0', '-map', '[s1]', 'out1', '-map', '[s2]', 'out2', '-map', '[s3]', 'out3', '-map', '[s4]', 'out4']
```

Split filter is now used as `split=5`, which works. Should be done automatically, but this works for now. I didn't want to subclass stuff as I saw you're trying to avoid that as much as possible.

We could subclass `FilterNode` to `SplitNode` and override `stream` to take note of how many splits are actually being done.
