### PR TITLE
Update ffmpeg build URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 before_install:
   - >
     [ -f ffmpeg-3.3.1-64bit-static/ffmpeg ] || (
-        curl -O https://johnvansickle.com/ffmpeg/releases/ffmpeg-3.3.1-64bit-static.tar.xz &&
+        curl -O https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz &&
         tar Jxf ffmpeg-3.3.1-64bit-static.tar.xz
     )
 matrix:


### PR DESCRIPTION
Looks like he started using "release" in the link, instead of the most recent version number which changes over time.