### PR TITLE
Update ffmpeg build URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 before_install:
   - >
-    [ -f ffmpeg-release-64bit-static/ffmpeg ] || (
+    [ -f ffmpeg-3.3.4-64bit-static/ffmpeg ] || (
         curl -O https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz &&
         tar Jxf ffmpeg-release-64bit-static.tar.xz
     )
@@ -28,9 +28,9 @@ matrix:
 install:
   - pip install tox
 script:
-  - export PATH=$(readlink -f ffmpeg-release-64bit-static):$PATH
+  - export PATH=$(readlink -f ffmpeg-3.3.4-64bit-static):$PATH
   - tox -e $TOX_ENV
 cache:
   directories:
     - .tox
-    - ffmpeg-release-64bit-static
+    - ffmpeg-3.3.4-64bit-static

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 before_install:
   - >
     [ -f ffmpeg-3.3.1-64bit-static/ffmpeg ] || (
-        curl -O https://johnvansickle.com/ffmpeg/releases/ffmpeg-3.3.1-64bit-static.tar.xz &&
-        tar Jxf ffmpeg-3.3.1-64bit-static.tar.xz
+        curl -O https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz &&
+        tar Jxf ffmpeg-release-64bit-static.tar.xz
     )
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 before_install:
   - >
-    [ -f ffmpeg-3.3.1-64bit-static/ffmpeg ] || (
+    [ -f ffmpeg-release-64bit-static/ffmpeg ] || (
         curl -O https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz &&
         tar Jxf ffmpeg-release-64bit-static.tar.xz
     )
@@ -28,9 +28,9 @@ matrix:
 install:
   - pip install tox
 script:
-  - export PATH=$(readlink -f ffmpeg-3.3.1-64bit-static):$PATH
+  - export PATH=$(readlink -f ffmpeg-release-64bit-static):$PATH
   - tox -e $TOX_ENV
 cache:
   directories:
     - .tox
-    - ffmpeg-3.3.1-64bit-static
+    - ffmpeg-release-64bit-static

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 before_install:
   - >
-    [ -f ffmpeg-3.3.4-64bit-static/ffmpeg ] || (
+    [ -f ffmpeg-release/ffmpeg ] || (
         curl -O https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz &&
-        tar Jxf ffmpeg-release-64bit-static.tar.xz
+        mkdir -p ffmpeg-release &&
+        tar Jxf ffmpeg-release-64bit-static.tar.xz --strip-components=1 -C ffmpeg-release
     )
 matrix:
   include:
@@ -28,9 +29,9 @@ matrix:
 install:
   - pip install tox
 script:
-  - export PATH=$(readlink -f ffmpeg-3.3.4-64bit-static):$PATH
+  - export PATH=$(readlink -f ffmpeg-release):$PATH
   - tox -e $TOX_ENV
 cache:
   directories:
     - .tox
-    - ffmpeg-3.3.4-64bit-static
+    - ffmpeg-release


### PR DESCRIPTION
Looks like he started using "release" in the link, instead of the most recent version number which changes over time.

edit-
I noticed https://johnvansickle.com/ffmpeg/releases/ffmpeg-3.3.4-64bit-static.tar.xz would work too.         https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz would just be one fewer line to keep up to date
