### PR TITLE
#34: run non-interactively by default

### DIFF
--- a/ffmpeg/_ffmpeg.py
+++ b/ffmpeg/_ffmpeg.py
@@ -24,6 +24,14 @@ def input(filename, **kwargs):
 
 
 @output_operator()
+def overwrite_output(stream):
+    """No longer supported; see ``overwrite_output`` parameter of ``get_args`` function instead.
+    """
+    raise NameError('`overwrite_output` operator is no longer supported; see `overwrite_output` parameter of '
+        '`get_args` function instead')
+
+
+@output_operator()
 def merge_outputs(*streams):
     """Include all given outputs in one ffmpeg command line
     """
@@ -50,4 +58,5 @@ __all__ = [
     'input',
     'merge_outputs',
     'output',
+    'overwrite_output',
 ]

--- a/ffmpeg/_ffmpeg.py
+++ b/ffmpeg/_ffmpeg.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from .nodes import (
     filter_operator,
-    GlobalNode,
     InputNode,
     MergeOutputsNode,
     OutputNode,
@@ -22,15 +21,6 @@ def input(filename, **kwargs):
             raise ValueError("Can't specify both `format` and `f` kwargs")
         kwargs['format'] = fmt
     return InputNode(input.__name__, kwargs=kwargs).stream()
-
-
-@output_operator()
-def overwrite_output(stream):
-    """Overwrite output files without asking (ffmpeg ``-y`` option)
-
-    Official documentation: `Main options <https://ffmpeg.org/ffmpeg.html#Main-options>`__
-    """
-    return GlobalNode(stream, overwrite_output.__name__).stream()
 
 
 @output_operator()
@@ -60,5 +50,4 @@ __all__ = [
     'input',
     'merge_outputs',
     'output',
-    'overwrite_output',
 ]

--- a/ffmpeg/tests/test_ffmpeg.py
+++ b/ffmpeg/tests/test_ffmpeg.py
@@ -101,7 +101,7 @@ def test_stream_repr():
 
 def test_get_args_simple():
     out_file = ffmpeg.input('dummy.mp4').output('dummy2.mp4')
-    assert out_file.get_args() == ['-i', 'dummy.mp4', 'dummy2.mp4']
+    assert out_file.get_args() == ['-i', 'dummy.mp4', 'dummy2.mp4', '-y']
 
 
 def _get_complex_filter_example():
@@ -122,7 +122,6 @@ def _get_complex_filter_example():
         .overlay(overlay_file.hflip())
         .drawbox(50, 50, 120, 120, color='red', thickness=5)
         .output(TEST_OUTPUT_FILE1)
-        .overwrite_output()
     )
 
 
@@ -156,7 +155,7 @@ def test_filter_normal_arg_escape():
             .get_args()
         )
         assert args[:3] == ['-i', 'in', '-filter_complex']
-        assert args[4:] == ['-map', '[s0]', 'out']
+        assert args[4:] == ['-map', '[s0]', 'out', '-y']
         match = re.match(r'\[0\]drawtext=font=a((.|\n)*)b:text=test\[s0\]', args[3], re.MULTILINE)
         assert match is not None, 'Invalid -filter_complex arg: {!r}'.format(args[3])
         return match.group(1)
@@ -190,7 +189,7 @@ def test_filter_text_arg_str_escape():
             .get_args()
         )
         assert args[:3] == ['-i', 'in', '-filter_complex']
-        assert args[4:] == ['-map', '[s0]', 'out']
+        assert args[4:] == ['-map', '[s0]', 'out', '-y']
         match = re.match(r'\[0\]drawtext=text=a((.|\n)*)b\[s0\]', args[3], re.MULTILINE)
         assert match is not None, 'Invalid -filter_complex arg: {!r}'.format(args[3])
         return match.group(1)
@@ -226,7 +225,7 @@ def test_run_multi_output():
     in_ = ffmpeg.input(TEST_INPUT_FILE1)
     out1 = in_.output(TEST_OUTPUT_FILE1)
     out2 = in_.output(TEST_OUTPUT_FILE2)
-    ffmpeg.run([out1, out2], overwrite_output=True)
+    ffmpeg.run([out1, out2])
 
 
 def test_run_dummy_cmd():
@@ -253,7 +252,8 @@ def test_custom_filter():
         '-i', 'dummy.mp4',
         '-filter_complex', '[0]custom_filter=a:b:kwarg1=c[s0]',
         '-map', '[s0]',
-        'dummy2.mp4'
+        'dummy2.mp4',
+        '-y',
     ]
 
 
@@ -267,7 +267,8 @@ def test_custom_filter_fluent():
         '-i', 'dummy.mp4',
         '-filter_complex', '[0]custom_filter=a:b:kwarg1=c[s0]',
         '-map', '[s0]',
-        'dummy2.mp4'
+        'dummy2.mp4',
+        '-y',
     ]
 
 
@@ -276,10 +277,10 @@ def test_merge_outputs():
     out1 = in_.output('out1.mp4')
     out2 = in_.output('out2.mp4')
     assert ffmpeg.merge_outputs(out1, out2).get_args() == [
-        '-i', 'in.mp4', 'out1.mp4', 'out2.mp4'
+        '-i', 'in.mp4', 'out1.mp4', 'out2.mp4', '-y'
     ]
     assert ffmpeg.get_args([out1, out2]) == [
-        '-i', 'in.mp4', 'out2.mp4', 'out1.mp4'
+        '-i', 'in.mp4', 'out2.mp4', 'out1.mp4', '-y'
     ]
 
 
@@ -292,14 +293,16 @@ def test_multi_passthrough():
         '-i', 'in2.mp4',
         'out1.mp4',
         '-map', '[1]',  # FIXME: this should not be here (see #23)
-        'out2.mp4'
+        'out2.mp4',
+        '-y',
     ]
     assert ffmpeg.get_args([out1, out2]) == [
         '-i', 'in2.mp4',
         '-i', 'in1.mp4',
         'out2.mp4',
         '-map', '[1]',  # FIXME: this should not be here (see #23)
-        'out1.mp4'
+        'out1.mp4',
+        '-y',
     ]
 
 
@@ -327,7 +330,8 @@ def test_pipe():
             '[0]trim=start_frame=2[s0]',
         '-map', '[s0]',
         '-f', 'rawvideo',
-        'pipe:1'
+        'pipe:1',
+        '-y',
     ]
 
     cmd = ['ffmpeg'] + args

--- a/ffmpeg/tests/test_ffmpeg.py
+++ b/ffmpeg/tests/test_ffmpeg.py
@@ -99,6 +99,11 @@ def test_stream_repr():
     assert repr(dummy_out) == "dummy()[{!r}] <{}>".format(dummy_out.label, dummy_out.node.short_hash)
 
 
+def test_overwrite_output():
+    with pytest.raises(NameError):
+        ffmpeg.input('dummy.mp4').output('dummy2.mp4').overwrite_output()
+
+
 def test_get_args_simple():
     out_file = ffmpeg.input('dummy.mp4').output('dummy2.mp4')
     assert out_file.get_args() == ['-i', 'dummy.mp4', 'dummy2.mp4', '-y']

--- a/ffmpeg/tests/test_ffmpeg.py
+++ b/ffmpeg/tests/test_ffmpeg.py
@@ -102,6 +102,8 @@ def test_stream_repr():
 def test_get_args_simple():
     out_file = ffmpeg.input('dummy.mp4').output('dummy2.mp4')
     assert out_file.get_args() == ['-i', 'dummy.mp4', 'dummy2.mp4', '-y']
+    assert out_file.get_args(overwrite_output=False) == ['-i', 'dummy.mp4', 'dummy2.mp4', '-n']
+    assert out_file.get_args(overwrite_output=None) == ['-i', 'dummy.mp4', 'dummy2.mp4']
 
 
 def _get_complex_filter_example():


### PR DESCRIPTION
Having to explicitly specify `overwrite_output=True` is annoying. `ffmpeg-python` should by default run non-interactively.

The `overwrite_output=False` can still be specified in `run()` or `get_args()` to override the default behavior. I changed the `overwrite_output` operator to raise an exception though so that it can be removed in the future. It will require anyone using the operator to change their code before it'll run again. Might be a harsh deprecation strategy, but if someone thinks this is a bad idea and has a better strategy, feel free to let me know.