### PR TITLE
Remove python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ matrix:
     - python: 2.7
       env:
       - TOX_ENV=py27
-    - python: 3.3
-      env:
-      - TOX_ENV=py33
     - python: 3.4
       env:
       - TOX_ENV=py34

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy
+envlist = py27, py34, py35, py36, pypy
 
 [testenv]
 commands = py.test -vv


### PR DESCRIPTION
Remove python 3.3 support since pytest seems to no longer support 3.3.