### PR TITLE
Fix issue with input ss=0

### DIFF
--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -16,7 +16,7 @@ from .nodes import (
     get_stream_spec_nodes,
     FilterNode,
     GlobalNode,
-    InputNode,   
+    InputNode,
     OutputNode,
     output_operator,
 )
@@ -31,7 +31,7 @@ def _convert_kwargs_to_cmd_line_args(kwargs):
     for k in sorted(kwargs.keys()):
         v = kwargs[k]
         args.append('-{}'.format(k))
-        if v:
+        if v is not None:
             args.append('{}'.format(v))
     return args
 

--- a/ffmpeg/tests/test_ffmpeg.py
+++ b/ffmpeg/tests/test_ffmpeg.py
@@ -291,6 +291,11 @@ def test_merge_outputs():
     ]
 
 
+def test__input__start_time():
+    assert ffmpeg.input('in', ss=10.5).output('out').get_args() == ['-ss', '10.5', '-i', 'in', 'out']
+    assert ffmpeg.input('in', ss=0.0).output('out').get_args() == ['-ss', '0.0', '-i', 'in', 'out']
+
+
 def test_multi_passthrough():
     out1 = ffmpeg.input('in1.mp4').output('out1.mp4')
     out2 = ffmpeg.input('in2.mp4').output('out2.mp4')


### PR DESCRIPTION
Creating an input with `ss=0` caused the value to be left off of the command-line after `-ss`:
```
In : (ffmpeg.input('in', ss=0).output('out').get_args())
Out: [u'-ss', u'-i', 'in', 'out']
```

With this fix:
```
In : (ffmpeg.input('in', ss=0).output('out').get_args())
Out: [u'-ss', u'0', u'-i', 'in', 'out']
```