### PR TITLE
Cleanup graph source file after rendering graph to pdf

### DIFF
--- a/ffmpeg/_view.py
+++ b/ffmpeg/_view.py
@@ -76,7 +76,7 @@ def view(stream_spec, **kwargs):
             downstream_node_id = str(hash(edge.downstream_node))
             graph.edge(upstream_node_id, downstream_node_id, **kwargs)
 
-    graph.view(filename)
+    graph.view(filename, cleanup=True)
 
     return stream_spec
 


### PR DESCRIPTION
Prevent leaving unwanted files.

Uses this option:
https://github.com/xflr6/graphviz/blob/master/graphviz/files.py#L192