### PR TITLE
add "install dependencies" into Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ pip install ffmpeg-python
 It's also possible to clone the source and put it on your python path (`$PYTHONPATH`, `sys.path`, etc.):
 ```bash
 $ git clone git@github.com:kkroening/ffmpeg-python.git
+$ pip install ffmpeg-python
 $ export PYTHONPATH=${PYTHONPATH}:ffmpeg-python
 $ python
 >>> import ffmpeg


### PR DESCRIPTION
Need to do "pip install ffmpeg-python".  Otherwise:

```
python -c 'import ffmpeg'
ModuleNotFoundError: No module named 'past'
```

This is inside a Docker container started with "FROM python"
```
# python --version
Python 3.6.4
# uname -a
Linux cd6979d97c72 4.9.60-linuxkit-aufs #1 SMP Mon Nov 6 16:00:12 UTC 2017 x86_64 GNU/Linux
```