### PR TITLE
Add `filter_multi_output` to `__all__` so it's available in API

### DIFF
--- a/ffmpeg/_filters.py
+++ b/ffmpeg/_filters.py
@@ -421,6 +421,7 @@ __all__ = [
     'drawbox',
     'drawtext',
     'filter_',
+    'filter_multi_output',
     'hflip',
     'hue',
     'overlay',


### PR DESCRIPTION
Fixes issue mentioned in #64 sample code