### PR TITLE
Fix `-map` to not use brackets for passthroughs; fixes #102, #23

### DIFF
--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -57,13 +57,19 @@ def _get_input_args(input_node):
     return args
 
 
-def _format_input_stream_name(stream_name_map, edge):
+def _format_input_stream_name(stream_name_map, edge, is_final_arg=False):
     prefix = stream_name_map[edge.upstream_node, edge.upstream_label]
     if not edge.upstream_selector:
         suffix = ''
     else:
         suffix = ':{}'.format(edge.upstream_selector)
-    return '[{}{}]'.format(prefix, suffix)
+    if is_final_arg and isinstance(edge.upstream_node, InputNode):
+        ## Special case: `-map` args should not have brackets for input
+        ## nodes.
+        fmt = '{}{}'
+    else:
+        fmt = '[{}{}]'
+    return fmt.format(prefix, suffix)
 
 
 def _format_output_stream_name(stream_name_map, edge):
@@ -113,8 +119,8 @@ def _get_output_args(node, stream_name_map):
 
     for edge in node.incoming_edges:
         # edge = node.incoming_edges[0]
-        stream_name = _format_input_stream_name(stream_name_map, edge)
-        if stream_name != '[0]' or len(node.incoming_edges) > 1:
+        stream_name = _format_input_stream_name(stream_name_map, edge, is_final_arg=True)
+        if stream_name != '0' or len(node.incoming_edges) > 1:
             args += ['-map', stream_name]
 
     kwargs = copy.copy(node.kwargs)

--- a/ffmpeg/tests/test_ffmpeg.py
+++ b/ffmpeg/tests/test_ffmpeg.py
@@ -165,8 +165,8 @@ def test_combined_output():
     assert out.get_args() == [
         '-i', TEST_INPUT_FILE1,
         '-i', TEST_OVERLAY_FILE,
-        '-map', '[0]',
-        '-map', '[1]',
+        '-map', '0',
+        '-map', '1',
         TEST_OUTPUT_FILE1
     ]
 
@@ -184,6 +184,7 @@ def test_filter_with_selector():
         '-map', '[s0]', '-map', '[s1]',
         TEST_OUTPUT_FILE1
     ]
+
 
 
 def test_get_item_with_bad_selectors():
@@ -532,15 +533,47 @@ def test_multi_passthrough():
         '-i', 'in1.mp4',
         '-i', 'in2.mp4',
         'out1.mp4',
-        '-map', '[1]',  # FIXME: this should not be here (see #23)
+        '-map', '1',
         'out2.mp4'
     ]
     assert ffmpeg.get_args([out1, out2]) == [
         '-i', 'in2.mp4',
         '-i', 'in1.mp4',
         'out2.mp4',
-        '-map', '[1]',  # FIXME: this should not be here (see #23)
+        '-map', '1',
         'out1.mp4'
+    ]
+
+
+def test_passthrough_selectors():
+    i1 = ffmpeg.input(TEST_INPUT_FILE1)
+    args = (
+        ffmpeg
+        .output(i1['1'], i1['2'], TEST_OUTPUT_FILE1)
+        .get_args()
+    )
+    assert args == [
+        '-i', TEST_INPUT_FILE1,
+        '-map', '0:1',
+        '-map', '0:2',
+        TEST_OUTPUT_FILE1,
+    ]
+
+
+def test_mixed_passthrough_selectors():
+    i1 = ffmpeg.input(TEST_INPUT_FILE1)
+    args = (
+        ffmpeg
+        .output(i1['1'].hflip(), i1['2'], TEST_OUTPUT_FILE1)
+        .get_args()
+    )
+    assert args == [
+        '-i', TEST_INPUT_FILE1,
+        '-filter_complex',
+        '[0:1]hflip[s0]',
+        '-map', '[s0]',
+        '-map', '0:2',
+        TEST_OUTPUT_FILE1,
     ]
 
 


### PR DESCRIPTION
See #102 and #23.