### PR TITLE
Fix CI issue with ffmpeg download link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 before_install:
   - >
     [ -f ffmpeg-release/ffmpeg ] || (
-        curl -O https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz &&
+        curl -O https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz &&
         mkdir -p ffmpeg-release &&
-        tar Jxf ffmpeg-release-64bit-static.tar.xz --strip-components=1 -C ffmpeg-release
+        tar Jxf ffmpeg-release-amd64-static.tar.xz --strip-components=1 -C ffmpeg-release
     )
 matrix:
   include:


### PR DESCRIPTION
Small change to fix the link for downloading a static build of ffmpeg in CI.