### PR TITLE
Adds a way to pass through textmode for Subprocess.Popen

### DIFF
--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -176,7 +176,7 @@ def compile(stream_spec, cmd='ffmpeg', overwrite_output=False):
 @output_operator()
 def run_async(
         stream_spec, cmd='ffmpeg', pipe_stdin=False, pipe_stdout=False, pipe_stderr=False,
-        quiet=False, overwrite_output=False):
+        quiet=False, overwrite_output=False, popen_textmode=None):
     """Asynchronously invoke ffmpeg for the supplied node graph.
 
     Args:
@@ -259,13 +259,13 @@ def run_async(
     stdout_stream = subprocess.PIPE if pipe_stdout or quiet else None
     stderr_stream = subprocess.PIPE if pipe_stderr or quiet else None
     return subprocess.Popen(
-        args, stdin=stdin_stream, stdout=stdout_stream, stderr=stderr_stream)
+        args, stdin=stdin_stream, stdout=stdout_stream, stderr=stderr_stream, text=popen_textmode)
 
 
 @output_operator()
 def run(
         stream_spec, cmd='ffmpeg', capture_stdout=False, capture_stderr=False, input=None,
-        quiet=False, overwrite_output=False):
+        quiet=False, overwrite_output=False, popen_textmode=None):
     """Invoke ffmpeg for the supplied node graph.
 
     Args:
@@ -288,6 +288,7 @@ def run(
         pipe_stderr=capture_stderr,
         quiet=quiet,
         overwrite_output=overwrite_output,
+		popen_textmode=popen_textmode,
     )
     out, err = process.communicate(input)
     retcode = process.poll()


### PR DESCRIPTION
Subprocess.Popen textmode (argument 'text=') is needed for reading from ffmpeg's stderr to scrap for the frame count in an asynchronous way. This is wonderful for multiple jobs and when realtime feedback is needed (all the time apparently).
---
I felt the need for this when making a function to return progress asynchronously. However the issue is that you no longer get output from the ffmpeg process anymore heh.

I also wanted to add a ffmpeg.progress() to the package but I feel like it is too early perhaps and there are still some issues and optimizations that i want to make.

I felt like there is a high need for a simple progress feedback when i was searching around for it for myself, and since this package has been the mainframe of my work project i'd love to contribute to it.

Feel free to tell me any edits and or optimizations that I should do!