### PR TITLE
Drop `future` install-requirement

### DIFF
--- a/ffmpeg/_ffmpeg.py
+++ b/ffmpeg/_ffmpeg.py
@@ -1,6 +1,4 @@
 from __future__ import unicode_literals
-
-from past.builtins import basestring
 from ._utils import basestring
 
 from .nodes import (

--- a/ffmpeg/_utils.py
+++ b/ffmpeg/_utils.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from builtins import str
-from past.builtins import basestring
 import hashlib
 import sys
 

--- a/ffmpeg/nodes.py
+++ b/ffmpeg/nodes.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
-
-from past.builtins import basestring
 from .dag import KwargReprNode
-from ._utils import escape_chars, get_hash_int
+from ._utils import basestring
+from ._utils import escape_chars
+from ._utils import get_hash_int
 from builtins import object
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup
 from textwrap import dedent
+import sys
+
 
 version = '0.2.0'
 download_url = 'https://github.com/kkroening/ffmpeg-python/archive/v{}.zip'.format(
@@ -57,6 +59,19 @@ misc_keywords = [
 
 keywords = misc_keywords + file_formats
 
+
+dev_requires = [
+    'future>=0.17.1',
+    'numpy>=1.16.4',
+    'pytest-mock>=1.10.4',
+    'pytest>=4.6.1',
+    'tox>=3.12.1',
+]
+
+if sys.version_info[0] >= 3:
+    dev_requires += ['Sphinx>=2.1.0']
+
+
 setup(
     name='ffmpeg-python',
     packages=['ffmpeg'],
@@ -70,17 +85,8 @@ setup(
     download_url=download_url,
     keywords=keywords,
     long_description=long_description,
-    install_requires=['future'],
-    extras_require={
-        'dev': [
-            'future==0.17.1',
-            'numpy==1.16.4',
-            'pytest-mock==1.10.4',
-            'pytest==4.6.1',
-            'Sphinx==2.1.0',
-            'tox==3.12.1',
-        ]
-    },
+    install_requires=[],
+    extras_require={'dev': dev_requires},
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
The `future` requirement has only been used for the `basestring` type, which was vendored into `_utils.py` in df9bd7316f and isn't actually necessary.

By stripping out the `future` requirement, ffmpeg-python no longer has any install-requirements, making installation less error-prone in certain cases.

Fixes #228 and #130.