### PR TITLE
Add optional timeout argument to probe

### DIFF
--- a/ffmpeg/_probe.py
+++ b/ffmpeg/_probe.py
@@ -18,7 +18,10 @@ def probe(filename, cmd='ffprobe', timeout=None, **kwargs):
     args += [filename]
 
     p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate(timeout=timeout)
+    communicate_kwargs = {}
+    if timeout is not None:
+        communicate_kwargs['timeout'] = timeout
+    out, err = p.communicate(**communicate_kwargs)
     if p.returncode != 0:
         raise Error('ffprobe', out, err)
     return json.loads(out.decode('utf-8'))

--- a/ffmpeg/_probe.py
+++ b/ffmpeg/_probe.py
@@ -4,7 +4,7 @@ from ._run import Error
 from ._utils import convert_kwargs_to_cmd_line_args
 
 
-def probe(filename, cmd='ffprobe', **kwargs):
+def probe(filename, cmd='ffprobe', timeout=None, **kwargs):
     """Run ffprobe on the specified file and return a JSON representation of the output.
 
     Raises:
@@ -18,7 +18,7 @@ def probe(filename, cmd='ffprobe', **kwargs):
     args += [filename]
 
     p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
+    out, err = p.communicate(timeout=timeout)
     if p.returncode != 0:
         raise Error('ffprobe', out, err)
     return json.loads(out.decode('utf-8'))

--- a/ffmpeg/tests/test_ffmpeg.py
+++ b/ffmpeg/tests/test_ffmpeg.py
@@ -8,6 +8,7 @@ import pytest
 import random
 import re
 import subprocess
+import sys
 
 try:
     import mock  # python 2
@@ -704,6 +705,13 @@ def test__probe():
     data = ffmpeg.probe(TEST_INPUT_FILE1)
     assert set(data.keys()) == {'format', 'streams'}
     assert data['format']['duration'] == '7.036000'
+
+
+@pytest.mark.skipif(sys.version_info < (3, 3), reason="requires python3.3 or higher")
+def test__probe_timeout():
+    with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+        data = ffmpeg.probe(TEST_INPUT_FILE1, timeout=0)
+    assert 'timed out after 0 seconds' in str(excinfo.value)
 
 
 def test__probe__exception():


### PR DESCRIPTION
Popen.communicate() supports a timeout argument which is useful in case
there is a risk that the probe hangs indefinitely.