### PR TITLE
Duplicate parameters can be set in kwargs with an iterator

### DIFF
--- a/ffmpeg/_utils.py
+++ b/ffmpeg/_utils.py
@@ -3,6 +3,8 @@ from builtins import str
 from past.builtins import basestring
 import hashlib
 import sys
+import collections
+
 
 if sys.version_info.major == 2:
     # noinspection PyUnresolvedReferences,PyShadowingBuiltins
@@ -91,6 +93,12 @@ def convert_kwargs_to_cmd_line_args(kwargs):
     args = []
     for k in sorted(kwargs.keys()):
         v = kwargs[k]
+        if isinstance(v, collections.Iterable) and not isinstance(v, str):
+            for value in v:
+                args.append('-{}'.format(k))
+                if value is not None:
+                    args.append('{}'.format(value))
+            continue
         args.append('-{}'.format(k))
         if v is not None:
             args.append('{}'.format(v))

--- a/ffmpeg/tests/test_ffmpeg.py
+++ b/ffmpeg/tests/test_ffmpeg.py
@@ -9,6 +9,7 @@ import random
 import re
 import subprocess
 
+
 try:
     import mock  # python 2
 except ImportError:
@@ -113,6 +114,10 @@ def test_stream_repr():
     assert repr(dummy_out) == 'dummy()[{!r}] <{}>'.format(
         dummy_out.label, dummy_out.node.short_hash
     )
+
+def test_repeated_args():
+    out_file = ffmpeg.input('dummy.mp4').output('dummy2.mp4', streamid=['0:0x101', '1:0x102'])
+    assert out_file.get_args() == ['-i', 'dummy.mp4', '-streamid', '0:0x101', '-streamid', '1:0x102', 'dummy2.mp4']
 
 
 def test__get_args__simple():


### PR DESCRIPTION
For instance, add multiple `streamid` in the output can be done like this:
```python
ffmpeg.input(url).output('video.mp4', streamid=['0:0x101', '1:0x102'])
```
will output this command line
`ffmpeg -i video.mp4 -streamid 0:0x101 -streamid 1:0x102 video.mp4`

Related to #285 