### PR TITLE
Changed the order of the argumets for output to appear last

### DIFF
--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -162,10 +162,10 @@ def get_args(stream_spec, overwrite_output=False):
     args += reduce(operator.add, [_get_input_args(node) for node in input_nodes])
     if filter_arg:
         args += ['-filter_complex', filter_arg]
+    args += reduce(operator.add, [_get_global_args(node) for node in global_nodes], [])
     args += reduce(
         operator.add, [_get_output_args(node, stream_name_map) for node in output_nodes]
     )
-    args += reduce(operator.add, [_get_global_args(node) for node in global_nodes], [])
     if overwrite_output:
         args += ['-y']
     return args


### PR DESCRIPTION
Hi,

The output arguments are defaulted to appear before the global arguments - This could cause issues with ffmepg command line as it expects all the stream arguments to be between the -i and -f.

See this example:
This would work: `ffmpeg -i ~/Movies/sample.ts -map data -c copy -f data -`
But this would return a "Stream not found" error: `ffmpeg -i ~/Movies/oparea4.ts -f data - -map data -c copy`


