### PR TITLE
Fix issue #195. Redirect stdout/err to /dev/null

### DIFF
--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -279,8 +279,10 @@ def run_async(
     """
     args = compile(stream_spec, cmd, overwrite_output=overwrite_output)
     stdin_stream = subprocess.PIPE if pipe_stdin else None
-    stdout_stream = subprocess.PIPE if pipe_stdout or quiet else None
-    stderr_stream = subprocess.PIPE if pipe_stderr or quiet else None
+    stdout_stream = subprocess.PIPE if pipe_stdout else None
+    stderr_stream = subprocess.PIPE if pipe_stderr else None
+    if quiet:
+        stdout_stream = stderr_stream = subprocess.DEVNULL
     return subprocess.Popen(
         args, stdin=stdin_stream, stdout=stdout_stream, stderr=stderr_stream
     )

--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -282,7 +282,8 @@ def run_async(
     stdout_stream = subprocess.PIPE if pipe_stdout else None
     stderr_stream = subprocess.PIPE if pipe_stderr else None
     if quiet:
-        stdout_stream = stderr_stream = subprocess.DEVNULL
+        stderr_stream = subprocess.STDOUT
+        stdout_stream = subprocess.DEVNULL
     return subprocess.Popen(
         args, stdin=stdin_stream, stdout=stdout_stream, stderr=stderr_stream
     )


### PR DESCRIPTION
Fixes #195 

Redirect stdout/stderr to DEVNULL when quiet is requested, otherwise, the buffer will be filled until a MemoryError on long encodings.