### PR TITLE
Implemented cwd parameter

### DIFF
--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -321,7 +321,7 @@ def run(
         pipe_stderr=capture_stderr,
         quiet=quiet,
         overwrite_output=overwrite_output,
-        cwd
+        cwd=cwd
     )
     out, err = process.communicate(input)
     retcode = process.poll()

--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -199,6 +199,7 @@ def run_async(
     pipe_stderr=False,
     quiet=False,
     overwrite_output=False,
+    cwd=None
 ):
     """Asynchronously invoke ffmpeg for the supplied node graph.
 
@@ -282,7 +283,8 @@ def run_async(
     stdout_stream = subprocess.PIPE if pipe_stdout or quiet else None
     stderr_stream = subprocess.PIPE if pipe_stderr or quiet else None
     return subprocess.Popen(
-        args, stdin=stdin_stream, stdout=stdout_stream, stderr=stderr_stream
+        args, stdin=stdin_stream, stdout=stdout_stream, stderr=stderr_stream,
+        cwd=cwd
     )
 
 
@@ -295,6 +297,7 @@ def run(
     input=None,
     quiet=False,
     overwrite_output=False,
+    cwd=None
 ):
     """Invoke ffmpeg for the supplied node graph.
 
@@ -318,6 +321,7 @@ def run(
         pipe_stderr=capture_stderr,
         quiet=quiet,
         overwrite_output=overwrite_output,
+        cwd
     )
     out, err = process.communicate(input)
     retcode = process.poll()

--- a/ffmpeg/tests/test_ffmpeg.py
+++ b/ffmpeg/tests/test_ffmpeg.py
@@ -441,12 +441,14 @@ def test__compile():
 @pytest.mark.parametrize('pipe_stdin', [True, False])
 @pytest.mark.parametrize('pipe_stdout', [True, False])
 @pytest.mark.parametrize('pipe_stderr', [True, False])
-def test__run_async(mocker, pipe_stdin, pipe_stdout, pipe_stderr):
+@pytest.mark.parametrize('cwd', [None, '/tmp'])
+def test__run_async(mocker, pipe_stdin, pipe_stdout, pipe_stderr, cwd):
     process__mock = mock.Mock()
     popen__mock = mocker.patch.object(subprocess, 'Popen', return_value=process__mock)
     stream = _get_simple_example()
     process = ffmpeg.run_async(
-        stream, pipe_stdin=pipe_stdin, pipe_stdout=pipe_stdout, pipe_stderr=pipe_stderr
+        stream, pipe_stdin=pipe_stdin, pipe_stdout=pipe_stdout,
+        pipe_stderr=pipe_stderr, cwd=cwd
     )
     assert process is process__mock
 
@@ -456,7 +458,8 @@ def test__run_async(mocker, pipe_stdin, pipe_stdout, pipe_stderr):
     (args,), kwargs = popen__mock.call_args
     assert args == ffmpeg.compile(stream)
     assert kwargs == dict(
-        stdin=expected_stdin, stdout=expected_stdout, stderr=expected_stderr
+        stdin=expected_stdin, stdout=expected_stdout, stderr=expected_stderr,
+        cwd=cwd
     )
 
 


### PR DESCRIPTION
Implemented the cwd parameter for run, run_async and compile functions.
Changing the working directory is useful when you spawn ffmpeg from multiple threads but each instance has to parse a list of relative paths, think of m3u8 playlists downloaded with aria2.