### PR TITLE
Fix typo in _run.py docstring

### DIFF
--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -233,7 +233,7 @@ def run_async(
             process = (
                 ffmpeg
                 .input(in_filename)
-                .output('pipe':, format='rawvideo', pix_fmt='rgb24')
+                .output('pipe:', format='rawvideo', pix_fmt='rgb24')
                 .run_async(pipe_stdout=True, pipe_stderr=True)
             )
             out, err = process.communicate()


### PR DESCRIPTION
`pipe:`