### PR TITLE
Adds atrim filter.

### DIFF
--- a/ffmpeg/_filters.py
+++ b/ffmpeg/_filters.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-from .nodes import FilterNode, filter_operator
 from ._utils import escape_chars
+from .nodes import FilterNode, filter_operator
 
 
 @filter_operator()
@@ -99,6 +99,28 @@ def trim(stream, **kwargs):
     Official documentation: `trim <https://ffmpeg.org/ffmpeg-filters.html#trim>`__
     """
     return FilterNode(stream, trim.__name__, kwargs=kwargs).stream()
+
+
+@filter_operator()
+def atrim(stream, **kwargs):
+    """Trim the audio input so that the output contains one continuous subpart of the input.
+
+    Args:
+        start: Specify the time of the start of the kept section, i.e. the sample with the timestamp start will be the
+            first frame in the output.
+        end: Specify the time of the first sample that will be dropped, i.e. the sample immediately preceding the one
+            with the timestamp end will be the last frame in the output.
+        start_pts: This is the same as start, except this option sets the start timestamp in timebase units instead of
+            seconds.
+        end_pts: This is the same as end, except this option sets the end timestamp in timebase units instead of
+            seconds.
+        duration: The maximum duration of the output in seconds.
+        start_sample: The number of the first frame that should be passed to the output.
+        end_sample: The number of the first frame that should be dropped.
+
+    Official documentation: `trim <https://ffmpeg.org/ffmpeg-filters.html#trim>`__
+    """
+    return FilterNode(stream, atrim.__name__, kwargs=kwargs).stream()
 
 
 @filter_operator()


### PR DESCRIPTION
I had been trying to trim audio files using the `trim` filter. After reading a bunch of ffmpeg documentation, it turns out you don't trim audio files with `trim`. I needed to use `atrim`, which hadn't been added to the api. Sooooo.... I added it. 

I'm not 100% sure what the best testing strategy is for adding new filters, they don't seem to be tested directly. If you need me to add a test, let me know.