### PR TITLE
Revert "Implemented cwd parameter"

### DIFF
--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -199,7 +199,6 @@ def run_async(
     pipe_stderr=False,
     quiet=False,
     overwrite_output=False,
-    cwd=None
 ):
     """Asynchronously invoke ffmpeg for the supplied node graph.
 
@@ -286,8 +285,7 @@ def run_async(
         stderr_stream = subprocess.STDOUT
         stdout_stream = subprocess.DEVNULL
     return subprocess.Popen(
-        args, stdin=stdin_stream, stdout=stdout_stream, stderr=stderr_stream,
-        cwd=cwd
+        args, stdin=stdin_stream, stdout=stdout_stream, stderr=stderr_stream
     )
 
 
@@ -300,7 +298,6 @@ def run(
     input=None,
     quiet=False,
     overwrite_output=False,
-    cwd=None
 ):
     """Invoke ffmpeg for the supplied node graph.
 
@@ -324,7 +321,6 @@ def run(
         pipe_stderr=capture_stderr,
         quiet=quiet,
         overwrite_output=overwrite_output,
-        cwd=cwd
     )
     out, err = process.communicate(input)
     retcode = process.poll()

--- a/ffmpeg/tests/test_ffmpeg.py
+++ b/ffmpeg/tests/test_ffmpeg.py
@@ -441,14 +441,12 @@ def test__compile():
 @pytest.mark.parametrize('pipe_stdin', [True, False])
 @pytest.mark.parametrize('pipe_stdout', [True, False])
 @pytest.mark.parametrize('pipe_stderr', [True, False])
-@pytest.mark.parametrize('cwd', [None, '/tmp'])
-def test__run_async(mocker, pipe_stdin, pipe_stdout, pipe_stderr, cwd):
+def test__run_async(mocker, pipe_stdin, pipe_stdout, pipe_stderr):
     process__mock = mock.Mock()
     popen__mock = mocker.patch.object(subprocess, 'Popen', return_value=process__mock)
     stream = _get_simple_example()
     process = ffmpeg.run_async(
-        stream, pipe_stdin=pipe_stdin, pipe_stdout=pipe_stdout,
-        pipe_stderr=pipe_stderr, cwd=cwd
+        stream, pipe_stdin=pipe_stdin, pipe_stdout=pipe_stdout, pipe_stderr=pipe_stderr
     )
     assert process is process__mock
 
@@ -458,8 +456,7 @@ def test__run_async(mocker, pipe_stdin, pipe_stdout, pipe_stderr, cwd):
     (args,), kwargs = popen__mock.call_args
     assert args == ffmpeg.compile(stream)
     assert kwargs == dict(
-        stdin=expected_stdin, stdout=expected_stdout, stderr=expected_stderr,
-        cwd=cwd
+        stdin=expected_stdin, stdout=expected_stdout, stderr=expected_stderr
     )
 
 


### PR DESCRIPTION
Reverts kkroening/ffmpeg-python#430

Reverting cause it broke CI builds. @Jacotsu can you please double-check it?