### PR TITLE
Revert "Revert "Implemented cwd parameter""

### DIFF
--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -199,6 +199,7 @@ def run_async(
     pipe_stderr=False,
     quiet=False,
     overwrite_output=False,
+    cwd=None
 ):
     """Asynchronously invoke ffmpeg for the supplied node graph.
 
@@ -285,7 +286,8 @@ def run_async(
         stderr_stream = subprocess.STDOUT
         stdout_stream = subprocess.DEVNULL
     return subprocess.Popen(
-        args, stdin=stdin_stream, stdout=stdout_stream, stderr=stderr_stream
+        args, stdin=stdin_stream, stdout=stdout_stream, stderr=stderr_stream,
+        cwd=cwd
     )
 
 
@@ -298,6 +300,7 @@ def run(
     input=None,
     quiet=False,
     overwrite_output=False,
+    cwd=None
 ):
     """Invoke ffmpeg for the supplied node graph.
 
@@ -321,6 +324,7 @@ def run(
         pipe_stderr=capture_stderr,
         quiet=quiet,
         overwrite_output=overwrite_output,
+        cwd=cwd
     )
     out, err = process.communicate(input)
     retcode = process.poll()

--- a/ffmpeg/tests/test_ffmpeg.py
+++ b/ffmpeg/tests/test_ffmpeg.py
@@ -441,12 +441,14 @@ def test__compile():
 @pytest.mark.parametrize('pipe_stdin', [True, False])
 @pytest.mark.parametrize('pipe_stdout', [True, False])
 @pytest.mark.parametrize('pipe_stderr', [True, False])
-def test__run_async(mocker, pipe_stdin, pipe_stdout, pipe_stderr):
+@pytest.mark.parametrize('cwd', [None, '/tmp'])
+def test__run_async(mocker, pipe_stdin, pipe_stdout, pipe_stderr, cwd):
     process__mock = mock.Mock()
     popen__mock = mocker.patch.object(subprocess, 'Popen', return_value=process__mock)
     stream = _get_simple_example()
     process = ffmpeg.run_async(
-        stream, pipe_stdin=pipe_stdin, pipe_stdout=pipe_stdout, pipe_stderr=pipe_stderr
+        stream, pipe_stdin=pipe_stdin, pipe_stdout=pipe_stdout,
+        pipe_stderr=pipe_stderr, cwd=cwd
     )
     assert process is process__mock
 
@@ -456,7 +458,8 @@ def test__run_async(mocker, pipe_stdin, pipe_stdout, pipe_stderr):
     (args,), kwargs = popen__mock.call_args
     assert args == ffmpeg.compile(stream)
     assert kwargs == dict(
-        stdin=expected_stdin, stdout=expected_stdout, stderr=expected_stderr
+        stdin=expected_stdin, stdout=expected_stdout, stderr=expected_stderr,
+        cwd=cwd
     )
 
 


### PR DESCRIPTION
Reverts kkroening/ffmpeg-python#493

It turns out that the issue is not caused by the PR, reverting the revert.