### PR TITLE
Avoid overriding "pipe" option with "quiet"

### DIFF
--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -280,11 +280,19 @@ def run_async(
     """
     args = compile(stream_spec, cmd, overwrite_output=overwrite_output)
     stdin_stream = subprocess.PIPE if pipe_stdin else None
-    stdout_stream = subprocess.PIPE if pipe_stdout else None
-    stderr_stream = subprocess.PIPE if pipe_stderr else None
+    stdout_stream = stderr_stream = None
+
     if quiet:
         stderr_stream = subprocess.STDOUT
         stdout_stream = subprocess.DEVNULL
+
+    if pipe_stdout:
+        stdout_stream = subprocess.PIPE
+        stderr_stream = subprocess.DEVNULL if quiet else None
+
+    if pipe_stderr:
+        stderr_stream = subprocess.PIPE
+
     return subprocess.Popen(
         args, stdin=stdin_stream, stdout=stdout_stream, stderr=stderr_stream,
         cwd=cwd


### PR DESCRIPTION
It is related to #195 #417 
PR #417 has fixed the issue #195 , but overriding pipe_stdout and pipe_stderr options.
There is a situation in my project where the video decoding subprocess need to mute stderr while piping frames via stdout to python process. With the current "quiet" implementation, the pipe_stdout will be muted.
Signed-off-by: ArchieMeng <archiemeng@protonmail.com>