### PR TITLE
new param on probe to get stderr

### DIFF
--- a/ffmpeg/_probe.py
+++ b/ffmpeg/_probe.py
@@ -4,7 +4,7 @@ from ._run import Error
 from ._utils import convert_kwargs_to_cmd_line_args
 
 
-def probe(filename, cmd='ffprobe', timeout=None, **kwargs):
+def probe(filename, cmd='ffprobe', timeout=None, capture_stderr=False, **kwargs):
     """Run ffprobe on the specified file and return a JSON representation of the output.
 
     Raises:
@@ -24,6 +24,8 @@ def probe(filename, cmd='ffprobe', timeout=None, **kwargs):
     out, err = p.communicate(**communicate_kwargs)
     if p.returncode != 0:
         raise Error('ffprobe', out, err)
+    if capture_stderr:
+        return json.loads(out.decode('utf-8')), err
     return json.loads(out.decode('utf-8'))
 
 


### PR DESCRIPTION
I need to get the stderr from probe even when it doesn't fail.
The reason why this is necessary is because there're important information to me on "Warning logs" `-v warning`.

So I created a new parameter `capture_stderr` with `False` as default value, what should make older versions working exactly the same way, but when using the `True` value, the function will return a tuple with the default return value on first position and the stderr on the second position.