### PR TITLE
Fix Issue #92

### DIFF
--- a/ffmpeg/__init__.py
+++ b/ffmpeg/__init__.py
@@ -20,3 +20,5 @@ __all__ = (
     + _view.__all__
     + _filters.__all__
 )
+
+__version__ = "0.2.0"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from tabnanny import verbose
 from setuptools import setup
 from textwrap import dedent
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
+from tabnanny import verbose
 from setuptools import setup
 from textwrap import dedent
 
-version = '0.2.0'
+
+import ffmpeg
+
+
+version = ffmpeg.__version__
 download_url = 'https://github.com/kkroening/ffmpeg-python/archive/v{}.zip'.format(
     version
 )


### PR DESCRIPTION
Close #92 

## Overview

- Fixed version information for easy access
- I implemented `__version__` style with reference to `yapf` from google. ( cf. [google/yapf](https://github.com/google/yapf) )


## What I checked

- All tests are green
- I can access version via `ffmpeg.__version__`

## Resources

See:
- https://github.com/google/yapf/blob/main/setup.py
- https://github.com/google/yapf/blob/main/yapf/__init__.py

