### PR TITLE
Fix Black in GHA for Python 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: psf/black@21.12b0 # TODO: upgrade after dropping Python 2 support.
-        with:
-          src: ffmpeg  # TODO: also format `examples`.
-          version: 21.12b0
+      - name: Black
+        run: |
+          # TODO: use standard `psf/black` action after dropping Python 2 support.
+          pip install black==21.12b0 click==8.0.2  # https://stackoverflow.com/questions/71673404
+          black ffmpeg --check --color --diff


### PR DESCRIPTION
CI has started failing due to the following error when attempting to run Black:
```
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/work/_actions/psf/black/21.12b0/.black-env/lib/python3.8/site-packages/click/__init__.py)
```

The issue is described in [Stack Overflow #71673404](https://stackoverflow.com/questions/71673404). But it's only problematic because of being tied to an older version of Black to support ancient Python 2.7 syntax.

We really need to kill off Python 2.7 support; but that's for a separate PR. This just stabilizes things for the time being.