### PR TITLE
fix(sec): upgrade urllib3 to 1.26.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ sphinxcontrib-qthelp==1.0.2
 sphinxcontrib-serializinghtml==1.1.3
 toml==0.10.0
 tox==3.12.1
-urllib3==1.25.3
+urllib3==1.26.5
 virtualenv==16.6.0
 wcwidth==0.1.7
 zipp==0.5.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.25.3
- [CVE-2021-33503](https://www.oscs1024.com/hd/CVE-2021-33503)


### What did I do？
Upgrade urllib3 from 1.25.3 to 1.26.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS