### PR TITLE
Feature error cmdline

### DIFF
--- a/examples/get_video_thumbnail.py
+++ b/examples/get_video_thumbnail.py
@@ -26,7 +26,7 @@ def generate_thumbnail(in_filename, out_filename, time, width):
             .run(capture_stdout=True, capture_stderr=True)
         )
     except ffmpeg.Error as e:
-        print(e.stderr.decode(), file=sys.stderr)
+        print(f"$ {e.cmdline}\n{e.stderr.decode()}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/examples/show_progress.py
+++ b/examples/show_progress.py
@@ -125,6 +125,6 @@ if __name__ == '__main__':
                 .run(capture_stdout=True, capture_stderr=True)
             )
         except ffmpeg.Error as e:
-            print(e.stderr, file=sys.stderr)
+            print(f"$ {e.cmdline}\n{e.stderr.decode()}", file=sys.stderr)
             sys.exit(1)
 

--- a/examples/transcribe.py
+++ b/examples/transcribe.py
@@ -27,7 +27,7 @@ def decode_audio(in_filename, **input_kwargs):
             .run(capture_stdout=True, capture_stderr=True)
         )
     except ffmpeg.Error as e:
-        print(e.stderr, file=sys.stderr)
+        print(f"$ {e.cmdline}\n{e.stderr.decode()}", file=sys.stderr)
         sys.exit(1)
     return out
 

--- a/examples/video_info.py
+++ b/examples/video_info.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     try:
         probe = ffmpeg.probe(args.in_filename)
     except ffmpeg.Error as e:
-        print(e.stderr, file=sys.stderr)
+        print(f"$ {e.cmdline}\n{e.stderr.decode()}", file=sys.stderr)
         sys.exit(1)
 
     video_stream = next((stream for stream in probe['streams'] if stream['codec_type'] == 'video'), None)

--- a/ffmpeg/_probe.py
+++ b/ffmpeg/_probe.py
@@ -1,7 +1,7 @@
 import json
 import subprocess
 from ._run import Error
-from ._utils import convert_kwargs_to_cmd_line_args
+from ._utils import convert_kwargs_to_cmd_line_args, convert_cmd_line_args_to_cmd_line_str
 
 
 def probe(filename, cmd='ffprobe', timeout=None, **kwargs):
@@ -23,7 +23,8 @@ def probe(filename, cmd='ffprobe', timeout=None, **kwargs):
         communicate_kwargs['timeout'] = timeout
     out, err = p.communicate(**communicate_kwargs)
     if p.returncode != 0:
-        raise Error('ffprobe', out, err)
+        cmdline = convert_cmd_line_args_to_cmd_line_str(args)
+        raise Error('ffprobe', out, err, cmdline)
     return json.loads(out.decode('utf-8'))
 
 

--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .dag import get_outgoing_edges, topo_sort
-from ._utils import basestring, convert_kwargs_to_cmd_line_args
+from ._utils import basestring, convert_kwargs_to_cmd_line_args, convert_cmd_line_args_to_cmd_line_str
 from builtins import str
 from functools import reduce
 import copy
@@ -24,12 +24,13 @@ except ImportError:
 
 
 class Error(Exception):
-    def __init__(self, cmd, stdout, stderr):
+    def __init__(self, cmd, stdout, stderr, cmdline):
         super(Error, self).__init__(
             '{} error (see stderr output for detail)'.format(cmd)
         )
         self.stdout = stdout
         self.stderr = stderr
+        self.cmdline = cmdline
 
 
 def _get_input_args(input_node):
@@ -334,7 +335,9 @@ def run(
     out, err = process.communicate(input)
     retcode = process.poll()
     if retcode:
-        raise Error('ffmpeg', out, err)
+        args = compile(stream_spec, cmd, overwrite_output=overwrite_output)
+        cmdline = convert_cmd_line_args_to_cmd_line_str(args)
+        raise Error('ffmpeg', out, err, cmdline)
     return out, err
 
 

--- a/ffmpeg/_utils.py
+++ b/ffmpeg/_utils.py
@@ -2,8 +2,9 @@ from __future__ import unicode_literals
 from builtins import str
 from past.builtins import basestring
 import hashlib
-import sys
-
+import sys, os
+import subprocess
+import shlex
 
 if sys.version_info.major == 2:
     # noinspection PyUnresolvedReferences,PyShadowingBuiltins
@@ -106,3 +107,11 @@ def convert_kwargs_to_cmd_line_args(kwargs):
         if v is not None:
             args.append('{}'.format(v))
     return args
+
+
+def convert_cmd_line_args_to_cmd_line_str(args):
+    """Helper function to build command line string from command line args."""
+    if os.name == "nt": # Windows system
+        return subprocess.list2cmdline(args)
+    # Non-windows systems
+    return shlex.join(args)


### PR DESCRIPTION
With this update, I'm proposing to add a `cmdline` argument to `ffmpeg.Error`.
This helps a lot when writing complex ffmpeg commands which might not work on the first attempt (e.g., wrong filename, filter name, filter, inputs, etc).

Examples are updated accordingly.