### PR TITLE
Fix hashlib error on FIPS=1 systems

### DIFF
--- a/ffmpeg/_utils.py
+++ b/ffmpeg/_utils.py
@@ -72,7 +72,7 @@ def _recursive_repr(item):
 
 def get_hash(item):
     repr_ = _recursive_repr(item).encode('utf-8')
-    return hashlib.md5(repr_).hexdigest()
+    return hashlib.md5(repr_, usedforsecurity=False).hexdigest()
 
 
 def get_hash_int(item):


### PR DESCRIPTION
Error when calling hashlib.md5 on systems where the FIPS=1 option is set