### PR TITLE
disabled window creation on windows

### DIFF
--- a/ffmpeg/_probe.py
+++ b/ffmpeg/_probe.py
@@ -1,4 +1,5 @@
 import json
+import sys
 import subprocess
 from ._run import Error
 from ._utils import convert_kwargs_to_cmd_line_args
@@ -17,7 +18,11 @@ def probe(filename, cmd='ffprobe', timeout=None, **kwargs):
     args += convert_kwargs_to_cmd_line_args(kwargs)
     args += [filename]
 
-    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    creation_flags = 0
+    if sys.platform == "win32":
+        creation_flags = subprocess.CREATE_NO_WINDOW
+
+    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, creationflags=creation_flags)
     communicate_kwargs = {}
     if timeout is not None:
         communicate_kwargs['timeout'] = timeout

--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -6,6 +6,7 @@ from functools import reduce
 import copy
 import operator
 import subprocess
+import sys
 
 from ._ffmpeg import input, output
 from .nodes import (
@@ -284,6 +285,11 @@ def run_async(
     stdin_stream = subprocess.PIPE if pipe_stdin else None
     stdout_stream = subprocess.PIPE if pipe_stdout else None
     stderr_stream = subprocess.PIPE if pipe_stderr else None
+
+    creation_flags = 0
+    if sys.platform == "win32":
+        creation_flags = subprocess.CREATE_NO_WINDOW
+
     if quiet:
         stderr_stream = subprocess.STDOUT
         stdout_stream = subprocess.DEVNULL
@@ -293,6 +299,7 @@ def run_async(
         stdout=stdout_stream,
         stderr=stderr_stream,
         cwd=cwd,
+        creationflags=creation_flags,
     )
 
 


### PR DESCRIPTION
If this package is used with PyInstaller --noconsole option, console window still opens when ffmpeg gets run. I added a creation flag to the subprocess.Popen that disables that behaviour (because if the user packages their script with --noconsole option, they probably don't want to see ffmepg output either). Note that this doesn't disable ffmpeg output to console, so if the program is run with the console (or used with PyInstaller without --noconsole flag), ffmpeg output can still be seen, which is in my opinion desirable behaviour. I also added a check so that this flag gets set only under Windows OS because I think the problem is specific to it.

Resolves #686, but in a better way than I first suggested there because using shell=True can be unsafe. This solution is better for described issue.