### PR TITLE
Use mkstemp instead of unsafe mktemp

### DIFF
--- a/ffmpeg/_view.py
+++ b/ffmpeg/_view.py
@@ -43,7 +43,7 @@ def view(stream_spec, detail=False, filename=None, pipe=False, **kwargs):
     if pipe and filename is not None:
         raise ValueError('Can\'t specify both `filename` and `pipe`')
     elif not pipe and filename is None:
-        filename = tempfile.mktemp()
+        filename = tempfile.mkstemp()[1]
 
     nodes = get_stream_spec_nodes(stream_spec)
 


### PR DESCRIPTION
The `tempfile.mktemp` function is unsafe and deprecated as per https://docs.python.org/3/library/tempfile.html#tempfile.mktemp. The security impact is mentioned here https://cwe.mitre.org/data/definitions/377.html.