### PR TITLE
Fix typo in `run_async` documentation

### DIFF
--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -269,7 +269,7 @@ def run_async(
                 )
                 out_frame = in_frame * 0.3
                 process2.stdin.write(
-                    frame
+                    out_frame
                     .astype(np.uint8)
                     .tobytes()
                 )


### PR DESCRIPTION
The example with `run_async` from the website is incorrect. 

The variable name should be `out_frame` instead of `frame`, which doesn't exist.