### PR TITLE
Fix empty strings returned in arguments 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cache
 .eggs
+.idea/
 .tox/
 dist/
 ffmpeg/tests/sample_data/out*.mp4

--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -170,9 +170,6 @@ def get_args(stream_spec, overwrite_output=False):
     args += reduce(operator.add, [_get_global_args(node) for node in global_nodes], [])
     if overwrite_output:
         args += ['-y']
-    for i, arg in enumerate(args):
-        if arg.startswith('[') and arg.endswith(']'):
-            args[i] = f'"{args}"'
     return args
 
 
@@ -192,7 +189,7 @@ def compile(stream_spec, cmd='ffmpeg', overwrite_output=False):
         cmd = [cmd]
     elif type(cmd) != list:
         cmd = list(cmd)
-    return cmd + get_args(stream_spec, overwrite_output=overwrite_output)
+    return cmd + list(filter(lambda x: x != '', get_args(stream_spec, overwrite_output=overwrite_output)))
 
 
 @output_operator()

--- a/ffmpeg/_run.py
+++ b/ffmpeg/_run.py
@@ -170,6 +170,9 @@ def get_args(stream_spec, overwrite_output=False):
     args += reduce(operator.add, [_get_global_args(node) for node in global_nodes], [])
     if overwrite_output:
         args += ['-y']
+    for i, arg in enumerate(args):
+        if arg.startswith('[') and arg.endswith(']'):
+            args[i] = f'"{args}"'
     return args
 
 


### PR DESCRIPTION
Due to [this](https://github.com/kkroening/ffmpeg-python/issues/842) issue I mentioned, I filtered empty  strings returned by get_args so compile and run functions can run properly.