### PR TITLE
Correct -re argument in example readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -222,13 +222,12 @@ server_url = "http://127.0.0.1:8080"
 
 process = (
     ffmpeg
-    .input("input.mp4")
+    .input("input.mp4", re=None) # argument to act as a live stream
     .output(
         server_url, 
         codec = "copy", # use same codecs of the original video
         listen=1, # enables HTTP server
         f=video_format)
-    .global_args("-re") # argument to act as a live stream
     .run()
 )
 


### PR DESCRIPTION
According to the ffmpeg document(https://ffmpeg.org/ffmpeg.html), the -re argument is an input option, not a global argument .

```
-re (input)
Read input at native frame rate. This is equivalent to setting -readrate 1.
```
The example in the readme ## Stream from a local video to HTTP server part code is not work, so I made a tiny correction.


